### PR TITLE
Created Cmdlet Get-DSClientOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,11 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+/libeay32.dll
+/boost_thread-vc100-mt-1_43.dll
+/boost_system-vc100-mt-1_43.dll
+/boost_regex-vc100-mt-1_43.dll
+/boost_filesystem-vc100-mt-1_43.dll
+/boost_date_time-vc100-mt-1_43.dll
+/SSPI.dll
+/ssleay32.dll

--- a/PSAsigraDSClient.csproj
+++ b/PSAsigraDSClient.csproj
@@ -34,7 +34,8 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsigraDSClientApi">
+    <Reference Include="AsigraDSClientApi, Version=1.0.6641.22813, Culture=neutral, PublicKeyToken=8a729e47b642c594, processorArchitecture=AMD64">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Libraries\DS-Client_API\Bindings\dotNet\x64\AsigraDSClientApi.dll</HintPath>
     </Reference>
     <Reference Include="System" />
@@ -85,6 +86,7 @@
     <Compile Include="PSAsigraDSClient\GetDSClientArchiveFilterRule.cs" />
     <Compile Include="PSAsigraDSClient\GetDSClientBackupSetItem.cs" />
     <Compile Include="PSAsigraDSClient\GetDSClientNocSettings.cs" />
+    <Compile Include="PSAsigraDSClient\GetDSClientOS.cs" />
     <Compile Include="PSAsigraDSClient\GetDSClientSupportedDataType.cs" />
     <Compile Include="PSAsigraDSClient\GetDSClientTools.cs" />
     <Compile Include="PSAsigraDSClient\InitializeDSClientBackupSetDelete.cs" />
@@ -276,7 +278,31 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="boost_date_time-vc100-mt-1_43.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="boost_filesystem-vc100-mt-1_43.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="boost_regex-vc100-mt-1_43.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="boost_system-vc100-mt-1_43.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="boost_thread-vc100-mt-1_43.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="libeay32.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="PSAsigraDSClient.dll-Help.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="ssleay32.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SSPI.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/PSAsigraDSClient.sln
+++ b/PSAsigraDSClient.sln
@@ -8,13 +8,18 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EBE176C0-7418-44E3-9FD4-B1BD61554A6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EBE176C0-7418-44E3-9FD4-B1BD61554A6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBE176C0-7418-44E3-9FD4-B1BD61554A6D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EBE176C0-7418-44E3-9FD4-B1BD61554A6D}.Debug|x64.Build.0 = Debug|Any CPU
 		{EBE176C0-7418-44E3-9FD4-B1BD61554A6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBE176C0-7418-44E3-9FD4-B1BD61554A6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBE176C0-7418-44E3-9FD4-B1BD61554A6D}.Release|x64.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PSAsigraDSClient/GetDSClientOS.cs
+++ b/PSAsigraDSClient/GetDSClientOS.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using System.Management.Automation;
+using AsigraDSClientApi;
+
+namespace PSAsigraDSClient.PSAsigraDSClient
+{
+    [Cmdlet(VerbsCommon.Get, "DSClientOS")]
+    [OutputType(typeof(DSClientOperatingSystem))]
+
+    public class GetDSClientOS: DSClientCmdlet
+    {
+        protected override void DSClientProcessRecord()
+        {
+            ClientConfiguration DSClientConfigMgr = DSClientSession.getConfigurationManager();
+
+            WriteVerbose("Retrieving DS-Client Operating System Type...");
+            EOSFlavour osType = DSClientConfigMgr.getClientOSType();
+
+            DSClientOperatingSystem dSclientOperatingSystem = new DSClientOperatingSystem(osType);
+
+            WriteObject(dSclientOperatingSystem);
+
+            DSClientConfigMgr.Dispose();
+        }
+
+        private class DSClientOperatingSystem
+        {
+            public string OperatingSystem { get; private set; }
+
+            public DSClientOperatingSystem(EOSFlavour osType)
+            {
+                OperatingSystem = osType.ToString()
+                                        .Split('_')
+                                        .Last();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Created new Cmdlet Get-DSClientOS

Converts the enum from EOSFlavor to a string and outputs a human readable string representing the Operating System the DS-Client is installed/running on